### PR TITLE
Terraform 0.13 compatibility

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-terraform 0.12.25
+terraform 0.13.6
 terraform-docs v0.9.1
-tflint 0.16.0
+tflint 0.21.0

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,10 @@
 terraform {
   required_providers {
     aws = {
+      source  = "hashicorp/aws"
       version = "~> 3.0"
     }
   }
 
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
Move the terraform config into versions.tf for consistency, bump required version to 0.13 and constrain the required providers.