### PR TITLE
Remove rogue .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-terraform 0.13.6
-terraform-docs v0.9.1
-tflint 0.21.0


### PR DESCRIPTION
Remove .tool-versions having it in the module causes no end of problems for terragrunt